### PR TITLE
Add perplexity output to chat/completion APIs

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1212,6 +1212,7 @@ class CompletionResponseChoice(OpenAIBaseModel):
             "including encountering the EOS token"),
     )
     prompt_logprobs: Optional[list[Optional[dict[int, Logprob]]]] = None
+    perplexity: Optional[float] = None
 
 
 class CompletionResponse(OpenAIBaseModel):
@@ -1359,6 +1360,7 @@ class ChatCompletionResponseChoice(OpenAIBaseModel):
     finish_reason: Optional[str] = "stop"
     # not part of the OpenAI spec but included in vLLM for legacy reasons
     stop_reason: Optional[Union[int, str]] = None
+    perplexity: Optional[float] = None
 
 
 class ChatCompletionResponse(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+import math
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
 from typing import Optional, Union, cast
@@ -454,6 +455,12 @@ class OpenAIServingCompletion(OpenAIServing):
                 else:
                     logprobs = None
 
+                if output.cumulative_logprob is not None and len(output.token_ids) > 0:
+                    perplexity = math.exp(-output.cumulative_logprob /
+                                          len(output.token_ids))
+                else:
+                    perplexity = None
+
                 choice_data = CompletionResponseChoice(
                     index=len(choices),
                     text=output_text,
@@ -461,6 +468,7 @@ class OpenAIServingCompletion(OpenAIServing):
                     finish_reason=output.finish_reason,
                     stop_reason=output.stop_reason,
                     prompt_logprobs=final_res.prompt_logprobs,
+                    perplexity=perplexity,
                 )
                 choices.append(choice_data)
 


### PR DESCRIPTION
## Summary
- extend `CompletionResponseChoice` and `ChatCompletionResponseChoice` with `perplexity`
- compute perplexity for each generated output in chat/completion handlers

## Testing
- `python -m py_compile vllm/entrypoints/openai/*.py`